### PR TITLE
Don't attempt to update the Postgres primary key sequence if the PK is a compound PK

### DIFF
--- a/lib/seed-fu/seeder.rb
+++ b/lib/seed-fu/seeder.rb
@@ -79,7 +79,7 @@ module SeedFu
       end
 
       def update_id_sequence
-        if @model_class.connection.adapter_name == "PostgreSQL"
+        if @model_class.connection.adapter_name == "PostgreSQL" && @model_class.primary_key.is_a?(String)
           quoted_id       = @model_class.connection.quote_column_name(@model_class.primary_key)
           quoted_sequence = "'" + @model_class.sequence_name + "'"
           @model_class.connection.execute(

--- a/lib/seed-fu/version.rb
+++ b/lib/seed-fu/version.rb
@@ -1,4 +1,4 @@
 module SeedFu
   # The current version of Seed Fu
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
http://compositekeys.rubyforge.org/ allows one to use compound primary keys with ActiveRecord. If the model is using a compound primary key, it returns an Array (rather than a String) for its primary_key method, and Seed Fu's attempt to update the Postgres sequence used to generate the PK will fail. (Composite primary keys are typically natural keys rather than surrogate sequence-derived keys, too, in which case there's no need to update a sequence anyway.)

This patch simply skips the sequence update attempt if the model class does not return a String as its primary key.
