### PR TITLE
Update rails related gem dependencies

### DIFF
--- a/seed-fu.gemspec
+++ b/seed-fu.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.summary     = "Easily manage seed data in your Active Record application"
   s.description = "Seed Fu is an attempt to once and for all solve the problem of inserting and maintaining seed data in a database. It uses a variety of techniques gathered from various places around the web and combines them to create what is hopefully the most robust seed data system around."
 
-  s.add_dependency "activerecord", "~> 3.1.0.rc4"
-  s.add_dependency "activesupport", "~> 3.1.0.rc4"
+  s.add_dependency "activerecord", "~> 3.1.0"
+  s.add_dependency "activesupport", "~> 3.1.0"
 
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "pg"


### PR DESCRIPTION
Rails 3.1.0 is out and I can't get this to install because it seems that "~> 3.1.0.rc4" does not let "3.1.0" satisfy the dependency.
