### PR TITLE
encoding problems

### DIFF
--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe SeedFu::Writer do
@@ -42,4 +43,17 @@ describe SeedFu::Writer do
 
     SeededModel.find(1).title.should == "Dr"
   end
+
+  it "should support specifying the output encoding to use" do
+    SeedFu::Writer.write(@file_name, :class_name => 'SeededModel', :encoding => "utf-8") do |writer|
+      writer << { :id => 1, :title => "Mr" }
+      writer << { :id => 2, :title => "Máster" }
+    end
+
+    File.read(@file_name).should include("# encoding: utf-8\n")
+
+    load @file_name
+    SeededModel.find(2).title.should == "Máster"
+  end
 end
+


### PR DESCRIPTION
I'm not sure if it is a problem or if i'm doing something bad.

I have a database with UTF-8 and I have simbols like á ñ ü and I'm ussing seed-fu:writer for write seed for this data.

when I try to use this seed I see that there are errors:

``` ruby
Localidad {:id=>26, :name=>"ALBARI\xC3\x91O", :departamento=>"PEHUAJO",
  :lat=>nil, :lng=>nil, :zoom=>nil, :provincia_id=>1}
Encoding::UndefinedConversionError: "\xC3" from ASCII-8BIT to UTF-8: INSERT INTO "localidades" ("created_at", "departamento", "id", "lat", "lng", "name", "provincia_id", "updated_at", "zoom") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
```

Is there something I can do?
