### PR TITLE
Add option to validate on save

### DIFF
--- a/lib/seed-fu/active_record_extension.rb
+++ b/lib/seed-fu/active_record_extension.rb
@@ -29,7 +29,12 @@ module SeedFu
     #       { :x => 5, :y => 9,  :name => "Office" }
     #     )
     def seed(*args, &block)
-      SeedFu::Seeder.new(self, *parse_seed_fu_args(args, block)).seed
+      do_seed({}, *args, &block)
+    end
+    
+    # Has the same behavior as {#seed}, but will run validations and raise an error if they fail.
+    def seed!(*args, &block)
+      do_seed({ :validate => true}, *args, &block)
     end
 
     # Has the same syntax as {#seed}, but if a record already exists with the same values for
@@ -40,11 +45,20 @@ module SeedFu
     #   Person.seed(:id, :id => 1, :name => "Bob") # => Name changed
     #   Person.seed(:id, :id => 1, :name => "Harry") # => Name *not* changed
     def seed_once(*args, &block)
-      constraints, data = parse_seed_fu_args(args, block)
-      SeedFu::Seeder.new(self, constraints, data, :insert_only => true).seed
+      do_seed({:insert_only => true}, *args, &block)
+    end
+    
+    # Has the same behavior as {#seed_once}, but will run validations and raise an error if they fail.
+    def seed_once!(*args, &block)
+      do_seed({:insert_only => true, :validate => true}, *args, &block)
     end
 
     private
+    
+      def do_seed(options, *args, &block)
+        constraints, data = parse_seed_fu_args(args, block)
+        SeedFu::Seeder.new(self, constraints, data, options).seed
+      end
 
       def parse_seed_fu_args(args, block)
         if block.nil?

--- a/lib/seed-fu/seeder.rb
+++ b/lib/seed-fu/seeder.rb
@@ -24,6 +24,7 @@ module SeedFu
       @options     = options.symbolize_keys
 
       @options[:quiet] ||= SeedFu.quiet
+      @options[:validate] ||= false  # replace nil with false
 
       validate_constraints!
       validate_data!
@@ -65,7 +66,7 @@ module SeedFu
         puts " - #{@model_class} #{data.inspect}" unless @options[:quiet]
 
         record.assign_attributes(data,  :without_protection => true)
-        record.save(:validate => false) || raise(ActiveRecord::RecordNotSaved)
+        record.save!(:validate => @options[:validate])
         record
       end
 

--- a/spec/seeder_spec.rb
+++ b/spec/seeder_spec.rb
@@ -123,7 +123,38 @@ describe SeedFu::Seeder do
   it "should not perform validation" do
     lambda { SeededModel.seed(:id => 1) }.should_not raise_error(ActiveRecord::RecordInvalid)
   end
-
+  
+  it "should validate attributes with seed!" do
+    expect do
+      SeededModel.seed!(:id) do |s|
+        s.id = 1
+        s.login = "bob"
+      end
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+    
+  it "should validate attributes with seed_once!" do
+    expect do
+      SeededModel.seed_once!(:id) do |s|
+        s.id = 1
+        s.login = "bob"
+      end
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+  
+  it "should pass validation with seed!" do
+    expect do
+      SeededModel.seed!(:id) do |s|
+        s.id = 1
+        s.login = "bob"
+        s.title = "Exists"
+      end
+    end.should_not raise_error(ActiveRecord::RecordInvalid)
+    
+    bob = SeededModel.find_by_id(1)
+    bob.title.should == 'Exists'
+  end
+  
   if ENV["DB"] == "postgresql"
     it "should update the primary key sequence after a records have been seeded" do
       id = SeededModel.connection.select_value("SELECT currval('seeded_models_id_seq')").to_i + 1


### PR DESCRIPTION
Currently, seeded models are not validated. As we use seeds for production as well, we prefer some validation overhead over potentially invalid data. Because of this, we implemented an option to validate the models on save and two new helper methods:

User.seed!(...) and User.seed_once!(...)

With these methods, an exception is thrown if validation fails. The rest of the API is completely backwards compatible.
