### PR TITLE
Writer#file_header joins command line args with a space

### DIFF
--- a/lib/seed-fu/writer.rb
+++ b/lib/seed-fu/writer.rb
@@ -105,7 +105,7 @@ module SeedFu
 # Seeding #{@options[:class_name]}
 # Written with the command:
 #
-#   #{$0} #{$*.join}
+#   #{$0} #{$*.join(' ')}
 #
         END
       end


### PR DESCRIPTION
better formatting of output of Writer#file_header, joining
command line args with a space.  E.g.:

before: `/path/to/rake seed_file:createTABLE=departmentOVERWRITE=true`

after: `/path/to/rake seed_file:create TABLE=department OVERWRITE=true`
