### PR TITLE
Change dependencies for Rails 4.0 Beta 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'http://rubygems.org'
-gem 'rails', "~> 3.1"
+gem 'rails', ">= 3.1"
 gemspec

--- a/seed-fu.gemspec
+++ b/seed-fu.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.summary     = "Easily manage seed data in your Active Record application"
   s.description = "Seed Fu is an attempt to once and for all solve the problem of inserting and maintaining seed data in a database. It uses a variety of techniques gathered from various places around the web and combines them to create what is hopefully the most robust seed data system around."
 
-  s.add_dependency "activerecord", "~> 3.1"
-  s.add_dependency "activesupport", "~> 3.1"
+  s.add_dependency "activerecord", ">= 3.1"
+  s.add_dependency "activesupport", ">= 3.1"
 
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "pg"


### PR DESCRIPTION
When I used seed-fu in Rails 4.0 Beta 1, its older version was installed because of the description of gemspec dependencies.
So, I changed them suitable for Rails 4.0.
