### PR TITLE
Add Capistrano3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ require 'seed-fu/capistrano'
 after 'deploy:update_code', 'db:seed_fu'
 ```
 
+If you use Capistrano3, you should require another file.
+
+```ruby
+require 'seed-fu/capistrano3'
+
+# Trigger the task before publishing
+before 'deploy:publishing', 'db:seed_fu'
+```
+
 Bugs / Feature requests
 -----------------------
 

--- a/lib/seed-fu/capistrano3.rb
+++ b/lib/seed-fu/capistrano3.rb
@@ -1,0 +1,1 @@
+load File.expand_path('../../tasks/seed_fu_capistrano3.rake', __FILE__)

--- a/lib/tasks/seed_fu_capistrano3.rake
+++ b/lib/tasks/seed_fu_capistrano3.rake
@@ -1,0 +1,12 @@
+namespace :db do
+  desc 'Load seed data into database'
+  task :seed_fu do
+    on roles(:db) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :bundle, :exec, :rake, 'db:seed_fu'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add rake task for capistrano3.

I want to ensure execute seed_fu after migrate, so I write example hook like this in README.
Please see this flow http://capistranorb.com/documentation/getting-started/flow/ 
