### PR TITLE
Fix update sequence error when a model don't use sequence

### DIFF
--- a/lib/seed-fu/seeder.rb
+++ b/lib/seed-fu/seeder.rb
@@ -85,7 +85,7 @@ module SeedFu
       end
 
       def update_id_sequence
-        if @model_class.connection.adapter_name == "PostgreSQL"
+        if @model_class.connection.adapter_name == "PostgreSQL" and @model_class.sequence_name.present?
           quoted_id       = @model_class.connection.quote_column_name(@model_class.primary_key)
           quoted_sequence = "'" + @model_class.sequence_name + "'"
           @model_class.connection.execute(


### PR DESCRIPTION
If using PostgreSQL and existing tables that don't have sequential primary key, a following error occurs:

```
TypeError: no implicit conversion of nil into String
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/seed-fu-2.3.1/lib/seed-fu/seeder.rb:90:in `+'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/seed-fu-2.3.1/lib/seed-fu/seeder.rb:90:in `update_id_sequence'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/seed-fu-2.3.1/lib/seed-fu/seeder.rb:38:in `seed'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/seed-fu-2.3.1/lib/seed-fu/active_record_extension.rb:32:in `seed'
/Users/suenami/Projects/commuca/db/seeds/correction_results.seeds.rb:3:in `block in define_seed_task'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/seedbank-0.3.0/lib/seedbank/dsl.rb:24:in `module_eval'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/seedbank-0.3.0/lib/seedbank/dsl.rb:24:in `block in define_seed_task'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:238:in `call'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:238:in `block in execute'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:235:in `each'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:235:in `execute'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:201:in `block in invoke_prerequisites'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:199:in `each'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:199:in `invoke_prerequisites'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:178:in `block in invoke_with_call_chain'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:201:in `block in invoke_prerequisites'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:199:in `each'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:199:in `invoke_prerequisites'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:178:in `block in invoke_with_call_chain'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/task.rb:165:in `invoke'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/application.rb:150:in `invoke_task'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/application.rb:106:in `each'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/application.rb:106:in `block in top_level'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/application.rb:115:in `run_with_threads'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/application.rb:100:in `top_level'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/application.rb:78:in `block in run'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/application.rb:176:in `standard_excep
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/lib/rake/application.rb:75:in `run'
/Users/suenami/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.2.2/bin/rake:33:in `<top (required)>'
/Users/suenami/.rbenv/versions/2.0.0-p353/bin/rake:23:in `load'
/Users/suenami/.rbenv/versions/2.0.0-p353/bin/rake:23:in `<main>'
```

So I modify to skip updating sequence if table don't use sequence.
