### PR TITLE
fix broken dependency (sqlite3 and active_record)

### DIFF
--- a/seed-fu.gemspec
+++ b/seed-fu.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "pg", '~> 0'
   s.add_development_dependency "mysql2", '~> 0'
-  s.add_development_dependency "sqlite3", '~> 0'
+  s.add_development_dependency "sqlite3", '~> 1'
 
   s.files        = Dir.glob("{lib}/**/*") + %w(LICENSE README.md CHANGELOG.md)
   s.require_path = 'lib'


### PR DESCRIPTION
active_record 4.x requires sqlite3-ruby 1.x.

``` sh
$ bundle install
$ bundle exec rspec spec

---
Using sqlite3 to run the tests.
/usr/local/opt/rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/activerecord-4.0.12/lib/active_record/connection_adapters/connection_specification.rb:58:in `rescue in resolve_hash_connection': Specified 'sqlite3' for database adapter, but the gem is not loaded. Add `gem 'sqlite3'` to your Gemfile. (Gem::LoadError)

---
```
