### PR TITLE
Remove implicit ordering when searching existing row by constraint

### DIFF
--- a/lib/seed-fu/seeder.rb
+++ b/lib/seed-fu/seeder.rb
@@ -76,7 +76,7 @@ module SeedFu
       end
 
       def find_or_initialize_record(data)
-        @model_class.where(constraint_conditions(data)).first ||
+        @model_class.where(constraint_conditions(data)).take ||
         @model_class.new
       end
 


### PR DESCRIPTION
When seed_fu is seeding, it first tries finding existing record, and this is done by a constraint:

`
City Load (1.9ms)  SELECT  "cities".* FROM "cities"  WHERE "cities"."id" = 5990  ORDER BY "cities"."id" ASC LIMIT 1
`
I think `order by` is redundant here, so I change `.first` to `.take`