### PR TITLE
add PostGIS adapter name detection

### DIFF
--- a/lib/seed-fu/seeder.rb
+++ b/lib/seed-fu/seeder.rb
@@ -85,7 +85,7 @@ module SeedFu
       end
 
       def update_id_sequence
-        if @model_class.connection.adapter_name == "PostgreSQL"
+        if @model_class.connection.adapter_name == "PostgreSQL" or @model_class.connection.adapter_name == "PostGIS"
           return if @model_class.primary_key.nil? || @model_class.sequence_name.nil?
 
           quoted_id       = @model_class.connection.quote_column_name(@model_class.primary_key)


### PR DESCRIPTION
Current code only check if the adapter_name is equal to "PostgreSQL". Since [PostGIS](https://github.com/rgeo/activerecord-postgis-adapter) adapter class is inherited from PostgreSQL, it should consider "PostGIS" as Postgresql adapter as well and run `nextval` to "table_index_seq".