### PR TITLE
Call eval with file and line nb so seeds fail with proper stracktraces

### DIFF
--- a/lib/seed-fu/runner.rb
+++ b/lib/seed-fu/runner.rb
@@ -35,15 +35,17 @@ module SeedFu
         ActiveRecord::Base.transaction do
           open(filename) do |file|
             chunked_ruby = ''
-            file.each_line do |line|
+            start_line = 1
+            file.each_line.with_index do |line, line_index|
               if line == "# BREAK EVAL\n"
-                eval(chunked_ruby)
+                eval(chunked_ruby, binding, filename, start_line)
+                start_line = line_index + 2
                 chunked_ruby = ''
               else
                 chunked_ruby << line
               end
             end
-            eval(chunked_ruby) unless chunked_ruby == ''
+            eval(chunked_ruby, binding, filename, start_line) unless chunked_ruby == ''
           end
         end
       end

--- a/spec/fixtures/with_errors/seeded_models_chunked.rb
+++ b/spec/fixtures/with_errors/seeded_models_chunked.rb
@@ -1,0 +1,4 @@
+# this is line 1
+# this is line 2
+# BREAK EVAL
+raise 'on line 4'

--- a/spec/fixtures/with_errors/seeded_models_straight.rb
+++ b/spec/fixtures/with_errors/seeded_models_straight.rb
@@ -1,0 +1,4 @@
+# this is line 1
+# this is line 2
+# this is line 3
+raise 'on line 4'

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -21,4 +21,18 @@ describe SeedFu::Runner do
     SeedFu.seed
     SeededModel.count.should == 3
   end
+
+  it "should give meaningful stacktraces" do
+    %w[straight chunked].each do |suffix|
+      begin
+        SeedFu.seed(File.dirname(__FILE__) + '/fixtures/with_errors', /_#{suffix}/)
+        fail "An exception was supposed to be raised"
+      rescue Exception => e
+        e.message.should == "on line 4"
+        e.backtrace.first.should =~ /seeded_models_#{suffix}.rb:4/
+      end
+    end
+  end
+
+
 end


### PR DESCRIPTION
Otherwise the stacktrace starts with `.../gems/seed-fu-2.3.6/lib/seed-fu/runner.rb:46:in`eval':` which is far from helpful.

This also adds a basic test of the runner with a file containing `# BREAK EVAL`
