### PR TITLE
Support ActiveRecord config loading

### DIFF
--- a/lib/seed-fu.rb
+++ b/lib/seed-fu.rb
@@ -31,6 +31,6 @@ module SeedFu
 end
 
 # @public
-class ActiveRecord::Base
+ActiveSupport.on_load(:active_record) do
   extend SeedFu::ActiveRecordExtension
 end


### PR DESCRIPTION
Use AS.on_load to avoid setting AR consts before config load.
It fixes `belongs_to_required_by_default` config behaviour disscussed in https://github.com/rails/rails/issues/23589