### PR TITLE
Fix ArgumentError in Rails 3.2

### DIFF
--- a/lib/seed-fu/seeder.rb
+++ b/lib/seed-fu/seeder.rb
@@ -76,7 +76,7 @@ module SeedFu
       end
 
       def find_or_initialize_record(data)
-        @model_class.where(constraint_conditions(data)).take ||
+        @model_class.where(constraint_conditions(data)).limit(1).to_a.first ||
         @model_class.new
       end
 


### PR DESCRIPTION
This PR fixes #115.

In Rails 3.2, ActiveRecord::FinderMethods#take does not exist ( added since Rails 4.0 http://apidock.com/rails/ActiveRecord/FinderMethods/take ), and ActiveRecord::Relation#take is processed as 'to_a.take' ( https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/relation/delegation.rb#L40 ).
Array#take requires 1 argument ( https://ruby-doc.org/core-2.2.0/Array.html#method-i-take ), but no arguments are passed in SeedFu::Seeder#find_or_initialize_record, so ArgumentError is raised.

I have 3 ideas to fix this issue.

1. Revert `take` to `first`.
2. Use `take(1).first` instead of `take`.
3. Use `limit(1).to_a.first` instead of `take`.

I choose No. 3 because the SQL is same in Rails 3.2 and 4.0. And I also consider Pull #89.

```ruby
User.where(name: 'Name').first
# Rails 3.2.22.5
#   => SELECT "users".* FROM "users" WHERE "users"."name" = 'Name' LIMIT 1
# Rails 4.0.13
#   => SELECT "users".* FROM "users" WHERE "users"."name" = 'Name' ORDER BY "users"."id" ASC LIMIT 1

User.where(name: 'Name').take(1).first
# Rails 3.2.22.5
#    => SELECT "users".* FROM "users" WHERE "users"."name" = 'Name'
# Rails 4.0.13
#    => SELECT "users".* FROM "users" WHERE "users"."name" = 'Name' LIMIT 1

User.where(name: 'Name').limit(1).to_a.first
# Rails 3.2.22.5
#    => SELECT "users".* FROM "users" WHERE "users"."name" = 'Name' LIMIT 1
# Rails 4.0.13
#    => SELECT "users".* FROM "users" WHERE "users"."name" = 'Name' LIMIT 1
```

If implicit order of ActiveRecord::FinderMethods#first (>= Rails 4.0) can be ignored, I think No. 1 may be better because it is easy to read.