### PR TITLE
Support PostgreSQL 10

### DIFF
--- a/lib/seed-fu/seeder.rb
+++ b/lib/seed-fu/seeder.rb
@@ -91,9 +91,17 @@ module SeedFu
           quoted_id       = @model_class.connection.quote_column_name(@model_class.primary_key)
           sequence = @model_class.sequence_name
 
-          @model_class.connection.execute <<-EOS
-            SELECT setval('#{sequence}', (SELECT GREATEST(MAX(#{quoted_id})+(SELECT increment_by FROM #{sequence}), (SELECT min_value FROM #{sequence})) FROM #{@model_class.quoted_table_name}), false)
-          EOS
+          if @model_class.connection.postgresql_version >= 100000
+            sql =<<-EOS
+              SELECT setval('#{sequence}', (SELECT GREATEST(MAX(#{quoted_id})+(SELECT seqincrement FROM pg_sequence WHERE seqrelid = '#{sequence}'::regclass), (SELECT seqmin FROM pg_sequence WHERE seqrelid = '#{sequence}'::regclass)) FROM #{@model_class.quoted_table_name}), false)
+            EOS
+          else
+            sql =<<-EOS
+              SELECT setval('#{sequence}', (SELECT GREATEST(MAX(#{quoted_id})+(SELECT increment_by FROM #{sequence}), (SELECT min_value FROM #{sequence})) FROM #{@model_class.quoted_table_name}), false)
+            EOS
+          end
+
+          @model_class.connection.execute sql
         end
       end
   end


### PR DESCRIPTION
In PostgreSQL 10 environment, I saw the following error.

```
Failure/Error: SeedFu.seed

ActiveRecord::StatementInvalid:
  PG::UndefinedColumn: ERROR:  column "increment_by" does not exist
```
In version 10, it's introduced `pg_sequence` catalog that contains information about sequences. Each sequences no longer have increment_by and min_value.

