### PR TITLE
Use `ActiveSupport.on_load` to hook into ActiveRecord

### DIFF
--- a/lib/seed-fu.rb
+++ b/lib/seed-fu.rb
@@ -31,6 +31,6 @@ module SeedFu
 end
 
 # @public
-class ActiveRecord::Base
-  extend SeedFu::ActiveRecordExtension
+ActiveSupport.on_load :active_record do
+  ::ActiveRecord::Base.send :extend, SeedFu::ActiveRecordExtension
 end


### PR DESCRIPTION
I think this gem breaks `ActiveRecord` configuration in Rails 5.0.x. Because it does not hook `ActiveRecord` correctly.

Rails 5.1.x does not have this problem. Because [load_defaults](https://github.com/rails/rails/blob/5-1-stable/railties/lib/rails/application/configuration.rb#L57-L83) method is called in `config/application.rb` before this gem is loaded.

Related to: https://github.com/rails/rails/issues/23589

---

Example

```
rails _5.0.6_ new ArHookBug
cd ArHookBug
rails g scaffold user name:string
rails g scaffold profile user:references address:string
rails db:migrate
rails s

# Open http://localhost:3000/profiles/new
# Click `Create Profile`
# You can't create a user because `User must exist`. This is correct.

echo "gem 'seed-fu'" >> Gemfile
bundle
rails s

# Open http://localhost:3000/profiles/new
# Click `Create Profile`
# You can create a user, but it shouldn't.
```
