### PR TITLE
Restore support for PostgreSQL with Rails versions before 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 2.3.8
+-------------
+
+Bug fixes:
+
+* Restored support for PostgreSQL with Rails versions before 5.0.0 broken in Seed Fu 2.3.7.
+
 Version 2.3.7
 -------------
 

--- a/lib/seed-fu/seeder.rb
+++ b/lib/seed-fu/seeder.rb
@@ -91,7 +91,8 @@ module SeedFu
           quoted_id       = @model_class.connection.quote_column_name(@model_class.primary_key)
           sequence = @model_class.sequence_name
 
-          if @model_class.connection.postgresql_version >= 100000
+          # TODO postgresql_version was made public in Rails 5.0.0, remove #send when support for earlier versions are dropped
+          if @model_class.connection.send(:postgresql_version) >= 100000
             sql =<<-EOS
               SELECT setval('#{sequence}', (SELECT GREATEST(MAX(#{quoted_id})+(SELECT seqincrement FROM pg_sequence WHERE seqrelid = '#{sequence}'::regclass), (SELECT seqmin FROM pg_sequence WHERE seqrelid = '#{sequence}'::regclass)) FROM #{@model_class.quoted_table_name}), false)
             EOS


### PR DESCRIPTION
Seed Fu supports Rails versions before 5.0.0 but #121 broken this when using PostgreSQL.  

[That change calls the `postgresql_version` method](https://github.com/mbleigh/seed-fu/commit/52072e7e74db592008e8a222c75695877b70caea#diff-af6276caf29740f938561d4cb392e206R94).  This method exists in all Rails versions that Seed Fu supports but it is only public since Rails 5.0.0.

 - [Rails 5.0.0 (public)](https://github.com/rails/rails/blob/v5.0.0/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L399)
 - [Rails 4.2.10 (protected)](https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L403-L406)
- [Rails 3.1.0 (protected)](https://github.com/rails/rails/blob/v3.1.0/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L943-L947)

#121 was released in Seed Fu 2.3.7.  This pull request restores support for Rails versions before 5.0.0 and I suggest it be released as 2.3.8.