### PR TITLE
Add `QUIET` option to the rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 2.3.10
+-------------
+
+Features:
+
+* Add `QUIET` option to the rake task.
+
 Version 2.3.8
 -------------
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ When loading lots of records, the above block-based syntax can be quite verbose.
 Rake task
 ---------
 
-Seed files can be run automatically using `rake db:seed_fu`. There are two options which you can pass:
+Seed files can be run automatically using `rake db:seed_fu`. There are following options which you can pass:
 
 * `rake db:seed_fu FIXTURE_PATH=path/to/fixtures` -- Where to find the fixtures
 * `rake db:seed_fu FILTER=users,articles` -- Only run seed files with a filename matching the `FILTER`
+* `rake db:seed_fu QUIET=true` -- Same effect as `SeedFu.quiet = true`
 
 You can also do a similar thing in your code by calling `SeedFu.seed(fixture_paths, filter)`.
 

--- a/lib/tasks/seed_fu.rake
+++ b/lib/tasks/seed_fu.rake
@@ -23,6 +23,9 @@ namespace :db do
 
       # to load files from RAILS_ROOT/features/fixtures
       rake db:seed_fu FIXTURE_PATH=features/fixtures
+
+      # to disable output
+      rake db:seed_fu QUIET=true
   EOS
   task :seed_fu => :environment do
     if ENV["FILTER"]
@@ -31,6 +34,10 @@ namespace :db do
 
     if ENV["FIXTURE_PATH"]
       fixture_paths = [ENV["FIXTURE_PATH"], ENV["FIXTURE_PATH"] + '/' + Rails.env]
+    end
+
+    if ENV["QUIET"] == "true"
+      SeedFu.quiet = true
     end
 
     SeedFu.seed(fixture_paths, filter)


### PR DESCRIPTION
Hi. I always uses this gem at work. 😃 ✋

When I use this gem with [`parallel_tests`](https://github.com/grosser/parallel_tests), I feel annoying at too much output of `rake db:seed_fu` for multiple databases. 😖

So, I open this PR to add option to disable output of `rake db:seed_fu`.

What do you think about this idea?

Thanks.
 



