### PR TITLE
Help with debugging seeding-errors

### DIFF
--- a/lib/seed-fu/seeder.rb
+++ b/lib/seed-fu/seeder.rb
@@ -71,7 +71,7 @@ module SeedFu
         else
           record.assign_attributes(data)
         end
-        record.save(:validate => false) || raise(ActiveRecord::RecordNotSaved, 'Record not saved!')
+        record.save(:validate => false) || raise(ActiveRecord::RecordNotSaved.new('Record not saved!', record))
         record
       end
 


### PR DESCRIPTION
By passing the record into the Exception, the developer has one
more tool to debug the seed-process.