### PR TITLE
close io object when fixture writing has completed

### DIFF
--- a/lib/seed-fu/writer.rb
+++ b/lib/seed-fu/writer.rb
@@ -93,6 +93,7 @@ module SeedFu
         yield(self)
         @io.write(seed_footer)
         @io.write(file_footer)
+        @io.close
       ensure
         @io, @count = nil, nil
       end


### PR DESCRIPTION
So typically, when passing a block to `File.open`, the `IO` object with automatically close when the block terminates.  However, we have notice when attempting to write fixtures for largish database dumps that the `IO` stream is closing before the last few strings are written.

I believe the cause of this is here:

https://github.com/mbleigh/seed-fu/blob/master/lib/seed-fu/writer.rb#L96-L98

Basically, the `ensure` is killing the the stream before the last chunks have been written to the file by niling it.

I am not sure this solution is the best, but it solved our issue.  I might take a stab at refactoring this code later.