### PR TITLE
Make sure regexp not matched with project path

### DIFF
--- a/lib/seed-fu/runner.rb
+++ b/lib/seed-fu/runner.rb
@@ -66,7 +66,7 @@ module SeedFu
           filenames += (Dir[File.join(path, '*.rb')] + Dir[File.join(path, '*.rb.gz')]).sort
         end
         filenames.uniq!
-        filenames = filenames.find_all { |filename| filename =~ @filter } if @filter
+        filenames = filenames.find_all { |filename| filename.gsub(/^#{Regexp.quote(Rails.root.to_s)}/,'') =~ @filter } if @filter
         filenames
       end
   end


### PR DESCRIPTION
Seems like current filtering feature not working if filter regexp triggered by element of the project path.