### PR TITLE
Allow for mutable strings

### DIFF
--- a/lib/seed-fu/runner.rb
+++ b/lib/seed-fu/runner.rb
@@ -34,11 +34,11 @@ module SeedFu
 
         ActiveRecord::Base.transaction do
           open(filename) do |file|
-            chunked_ruby = ''
+            chunked_ruby = String.new('')
             file.each_line do |line|
               if line == "# BREAK EVAL\n"
                 eval(chunked_ruby)
-                chunked_ruby = ''
+                chunked_ruby = String.new('')
               else
                 chunked_ruby << line
               end

--- a/lib/seed-fu/writer.rb
+++ b/lib/seed-fu/writer.rb
@@ -67,7 +67,7 @@ module SeedFu
     def <<(seed)
       raise "You must add seeds inside a SeedFu::Writer#write block" unless @io
 
-      buffer = ''
+      buffer = String.new('')
 
       if chunk_this_seed?
         buffer << seed_footer


### PR DESCRIPTION
In Ruby 3.5+, literal strings will
be frozen. This change allows for
a mutable string.

closes #143 